### PR TITLE
Use readline to read with history

### DIFF
--- a/train
+++ b/train
@@ -20,8 +20,10 @@ fi
 
 cd "$1"
 
-touch success
-touch fail
+touch success fail history
+
+HISTFILE=history
+history -r
 
 red="$(tput setaf 1)"
 green="$(tput setaf 2)"
@@ -44,7 +46,9 @@ while true; do
 
     failed="NO"
     while true; do
-        read -r -p "$de: " entry || { echo; exit; }
+        read -r -e -p "$de: " entry || { echo; exit; }
+        history -s "$entry"
+        history -w
         if [[ "$ru" == "$entry" ]]; then
             echo "${green}Success${reset}"
             if [[ $failed == "NO" ]]; then


### PR DESCRIPTION
Each directory contains an additional file, `history`, which saves the history of everything the user enters. When reading input from the user, readline is used, and consults this history file. Thus, the user can access earlier entries with the arrow keys.

Unfortunately, `read` doesn’t seem to perform history expansion, so quick fixes like `^а^я` are not available.
